### PR TITLE
Update scribl.py to include kv support

### DIFF
--- a/scribl.py
+++ b/scribl.py
@@ -6,19 +6,34 @@
 #
 # Example:  scribl.py -d /opt/splunk/var/lib/splunk/bots/db/ -r 34.220.39.122 -p 20000 -t -n4 -l /tmp/scribl.log -et 1564819155 -lt 1566429310#
 #
+# Required:
+#  -d  Source directory containing the buckets.
+#  -r  Remote address to send the exported data to.  This should be your Cribl worker with a TCP listener opened up.
+#  -p  Remote TCP port to be used
+# Optional:
+#  -t  Send with TLS enabled
+#  -n  Number of parallel stream to utilize
+#  -l  Location to write/append the logging
+#  -et Earliest epoch time for bucket selection
+#  -lt Latest epoch time for bucket selection
+#  -kv Specify key=value to carry forward as a field in addition to _time, host, source, sourcetype, and _raw.  Can specify -kv multiple times
+#
 # Make sure nc (netcat) is in the path or hard code it below to fit your needs
+#
+# If you use the -kv option, make sure your pipeline in Cribl Stream accounts for the new field(s)
 
-import argparse,os,subprocess,sys,time,logging
+import argparse,os,subprocess,sys,time,logging,re
 from multiprocessing import Pool
 
 def getArgs(argv=None):
     parser = argparse.ArgumentParser(description="This is to be run on a Splunk Indexer for the purpose\
             of exporting buckets and streaming their contents to Cribl Stream")
     parser.add_argument("-t","--TLS", help="Send with TLS enabled", action='store_true')
-    parser.add_argument("-n","--numstreams", default="1", type=int, help="the number of parallel stream to utilize")
-    parser.add_argument("-l","--logfile", default="/tmp/SplunkToCribl.log", help="specify the location to write/append the logging")
-    parser.add_argument("-et","--earliest", default=0, type=int, help="specify the earliest epoch time for bucket selection")
-    parser.add_argument("-lt","--latest", default=9999999999, type=int, help="specify the latest epoch time for bucket selection")
+    parser.add_argument("-n","--numstreams", default="1", type=int, help="Number of parallel stream to utilize")
+    parser.add_argument("-l","--logfile", default="/tmp/SplunkToCribl.log", help="Location to write/append the logging")
+    parser.add_argument("-et","--earliest", default=0, type=int, help="Earliest epoch time for bucket selection")
+    parser.add_argument("-lt","--latest", default=9999999999, type=int, help="Latest epoch time for bucket selection")
+    parser.add_argument("-kv","--keyval", action='append', nargs='+', help="Specify key=value to carry forward as a field in addition to _time, host, source, sourcetype, and _raw.  Can specify -kv multiple times")
     requiredNamed = parser.add_argument_group('required named arguments')
     requiredNamed.add_argument("-d","--directory", help="Source directory containing the buckets", required=True)
     requiredNamed.add_argument("-r","--remoteIP", help="Remote address to send the exported data to", required=True)
@@ -39,12 +54,20 @@ def list_full_paths(directory,earliest,latest):
 def buildCmdList(buckets,args):
     cliCommands=[]
     for bucket in buckets:
-        exporttoolCmd="/opt/splunk/bin/splunk cmd exporttool "+bucket+" /dev/stdout -csv | nc "
+        exporttoolCmd="/opt/splunk/bin/splunk cmd exporttool "+bucket+" /dev/stdout -csv "
+        if args.keyval:
+            for pair in args.keyval:
+                result = re.search(r"..(.*)=(.*)..", str(pair))
+                kv="\""+result.group(1)+"::"+result.group(2)+"\""
+                exporttoolCmd+="|sed -e 's/^\([[:digit:]]\{10\},\)\(.*\)/\\1"+kv+",\\2/'"
+        exporttoolCmd+="| nc "
         if args.TLS:
             exporttoolCmd+="--ssl "
         exporttoolCmd+=args.remoteIP
         exporttoolCmd+=" "+args.remotePort
+        print(exporttoolCmd)
         cliCommands.append(exporttoolCmd)
+        logging.info("exporttoolCmd: %s ",exporttoolCmd)
     return cliCommands
 
 def runCmd(cmd):


### PR DESCRIPTION
This change adds a -kv switch that allows one to hardcode fields into the events that are sent to a cribl worker.